### PR TITLE
Potential fix for code scanning alert no. 1: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/src/backend/routers/auth.py
+++ b/src/backend/routers/auth.py
@@ -4,7 +4,7 @@ Authentication endpoints for the High School Management System API
 
 from fastapi import APIRouter, HTTPException
 from typing import Dict, Any
-import hashlib
+from argon2 import PasswordHasher
 
 from ..database import teachers_collection
 
@@ -13,20 +13,25 @@ router = APIRouter(
     tags=["auth"]
 )
 
+ph = PasswordHasher()
+
 def hash_password(password):
-    """Hash password using SHA-256"""
-    return hashlib.sha256(password.encode()).hexdigest()
+    """Hash password using Argon2"""
+    return ph.hash(password)
 
 @router.post("/login")
 def login(username: str, password: str) -> Dict[str, Any]:
     """Login a teacher account"""
-    # Hash the provided password
-    hashed_password = hash_password(password)
-    
     # Find the teacher in the database
     teacher = teachers_collection.find_one({"_id": username})
     
-    if not teacher or teacher["password"] != hashed_password:
+    if not teacher:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+    
+    try:
+        if not ph.verify(teacher["password"], password):
+            raise HTTPException(status_code=401, detail="Invalid username or password")
+    except Exception:
         raise HTTPException(status_code=401, detail="Invalid username or password")
     
     # Return teacher information (excluding password)


### PR DESCRIPTION
Potential fix for [https://github.com/Ahmad-Reza-Alfayiet/skills-introduction-to-repository-management/security/code-scanning/1](https://github.com/Ahmad-Reza-Alfayiet/skills-introduction-to-repository-management/security/code-scanning/1)

To fix this problem, replace the use of `hashlib.sha256` for password hashing with a modern, secure password hashing algorithm. The best approach is to use the `argon2-cffi` library, which provides a simple and secure interface for password hashing and verification. Specifically:

- Replace the `hash_password` function to use `argon2.PasswordHasher().hash(password)`.
- When verifying passwords (in the login function), use `argon2.PasswordHasher().verify(stored_hash, password)` instead of comparing hashes directly.
- Add the necessary import for `argon2.PasswordHasher`.
- Update any code that compares password hashes to use the `verify` method.
- No changes are needed to the rest of the authentication logic.

All changes are to be made in `src/backend/routers/auth.py`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
